### PR TITLE
Hide Settings text when side panel collapsed

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -134,6 +134,6 @@ export default {
   margin: 1px;
 }
 .area-title.flex-1.flex.justify-center.items-center{
-  padding: 12px;
+  padding: 12px 0;
 }
 </style>


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/24302436/78060835-22815500-7384-11ea-95a9-4263a8491649.png)
