### PR TITLE
Fixes & prepare for new Dave changes

### DIFF
--- a/src/views/Thread.vue
+++ b/src/views/Thread.vue
@@ -109,8 +109,11 @@ export default {
     addMessage (message) {
       switch (message.message_type) {
         case 1:
+          if (message.body.startsWith('**EDITED')) break // Bandaid fix
+
           let ageMatch = message.body.match(/ccount\sage:\*\*\s([^\n]+)/i)
           let noteMatch = message.body.match(/last\snote[^\*]+\*\*\s(.+?)-\s\[/i)
+
           if (ageMatch)
             this.accountAge = ageMatch[1]
           if (noteMatch) {

--- a/src/views/Thread.vue
+++ b/src/views/Thread.vue
@@ -8,7 +8,8 @@
         <div class="w-8 select-none flex flex-col">
           <div class="btnMsgToggle tippy-r select-none flex-1 flex items-center justify-center" :class="{ on: showMessages }"
           title="Toggle Channel Messages" @click="toggleMsgs">
-            <i class="text-lg fa fa-check"></i>
+            <i class="text-lg fa fa-comments">
+            </i>
           </div>
           <div title="Copy Thread ID" :data-clipboard-text="thread.id"
           class="btnOther copyBtn tippy-r flex-1 flex items-center justify-center">

--- a/src/views/Thread.vue
+++ b/src/views/Thread.vue
@@ -109,8 +109,8 @@ export default {
     addMessage (message) {
       switch (message.message_type) {
         case 1:
-          let ageMatch = message.body.match(/account age \*\*(.+?)\*\*/i)
-          let noteMatch = message.body.match(/\*\*note:\*\* (.+)\n/i)
+          let ageMatch = message.body.match(/ccount\sage:\*\*\s([^\n]+)/i)
+          let noteMatch = message.body.match(/last\snote[^\*]+\*\*\s(.+?)-\s\[/i)
           if (ageMatch)
             this.accountAge = ageMatch[1]
           if (noteMatch) {

--- a/src/views/Thread.vue
+++ b/src/views/Thread.vue
@@ -112,8 +112,8 @@ export default {
         case 1:
           if (message.body.startsWith('**EDITED')) break // Bandaid fix
 
-          let ageMatch = message.body.match(/ccount\sage:\*\*\s([^\n]+)/i)
-          let noteMatch = message.body.match(/last\snote[^\*]+\*\*\s(.+?)-\s\[/i)
+          let ageMatch = message.body.match(/ccount\sage[:\s]?\*\*\s?([^*]+)/i)
+          let noteMatch = message.body.match(/\n\*\*(?:last\s)?note[^\*]+\*\*\s(.+?)(?:\s-\s\[|\n)/i)
 
           if (ageMatch)
             this.accountAge = ageMatch[1]

--- a/src/views/Threads.vue
+++ b/src/views/Threads.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="scroller px-16 pt-4 h-full">
-    <p class="text-center text-4xl">Threads</p>
+    <p class="text-center text-4xl">{{ includePrivate ? "" : "Closed "}}Threads</p>
     <table cellspacing="0" class="my-4 w-full">
       <thead class="select-none">
         <th class="flex-inline items-center justify-center">
@@ -40,7 +40,7 @@
     </table>
     <paginator v-if="pageCount > 1" :pageCount="pageCount"
       :page="page" @select="selectPage"/>
-    <p class="result-count font-semibold text-center">{{ threads.length }} out of {{ threadCount }} results</p>
+    <p class="result-count font-semibold text-center">Showing {{ threads.length }} out of {{ threadCount }} results</p>
   </div>
 </template>
 
@@ -65,7 +65,8 @@ export default {
       pageCount: 1,
       reverse: true,
       sort: 'status',
-      threadCount: 0
+      threadCount: 0,
+      includePrivate: false
     }
   },
   watch: {
@@ -112,6 +113,7 @@ export default {
           this.pageCount = Math.ceil(res.body.total / this.settings.pageSize)
           this.threads = res.body.threads
           this.threadCount = res.body.total
+          this.includePrivate = res.body.includePrivate
         }
       })
     },

--- a/src/views/Threads.vue
+++ b/src/views/Threads.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="scroller px-16 pt-4 h-full">
-    <p class="text-center text-4xl">{{ includePrivate ? "" : "Closed "}}Threads</p>
+    <p class="text-center text-4xl">{{ includePrivate ? '' : 'Closed '}}Threads</p>
     <table cellspacing="0" class="my-4 w-full">
       <thead class="select-none">
         <th class="flex-inline items-center justify-center">

--- a/src/views/Threads.vue
+++ b/src/views/Threads.vue
@@ -14,7 +14,7 @@
             </div>
           </div>
         </th>
-        <th class="flex-inline items-center justify-center">
+        <th v-if="includePrivate" class="flex-inline items-center justify-center">
           <div class="sort" @click="sortStatus">
             <span>Status</span>
             <div class="ml-2 inline-block">


### PR DESCRIPTION
Dave has been updated, so something has broken on the dashboard. Along with this, I wanted to change and remove a few things:

 - Added new RegEx so the dashboard can match the new format of thread creation info.
 - The **system** edited message alert that gets sent when a user edits their message is now ignored.
 - Regular staff can no longer view threads which are currently open. Due to this, if the user viewing the dashboard doesn't have access to view private or open threads, the text above the threads list will say "Closed Threads". Along with this, these users cannot sort the "Status" column. This column will most likely be replaced in the future. These 2 changes don't affect users with Admin priviledges.
 - Changed the FA icon of the "Show Channel Messages" button.